### PR TITLE
Replace emoji codes with images

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -1,3 +1,9 @@
 .markdown-body {
     font-size: 11px;
 }
+
+img.emoji-img.emoji {
+  max-width: 11px;
+  max-height: 11px;
+  vertical-align: middle;
+}

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ let fs = require('fs');
 let path = require('path');
 let url = require('url');
 let showdown = require('showdown');
+let showdownEmoji = require('showdown-emoji');
 let cheerio = require('cheerio');
 let pdf = require('html-pdf');
 let Handlebars = require('handlebars');
@@ -54,7 +55,8 @@ function parseMarkdownToHtml(markdown) {
     showdown.setFlavor('github');
     let converter = new showdown.Converter({
         prefixHeaderId: false,
-        ghCompatibleHeaderId: true
+        ghCompatibleHeaderId: true,
+        extensions: [showdownEmoji]
     });
 
     return converter.makeHtml(markdown);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "handlebars": "^4.0.6",
     "html-pdf": "^2.1.0",
     "showdown": "^1.6.0",
+    "showdown-emoji": "^1.0.3",
     "yargs": "^6.6.0"
   }
 }


### PR DESCRIPTION
Add capability to replace emoji codes e.g. `:+1:` with images :+1: using the showdown plugin https://www.npmjs.com/package/showdown-emoji