### PR TITLE
Resolve image paths relative to the MD file

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,13 +78,15 @@ function hasAcceptableProtocol(src) {
 	return new RegExp(acceptableProtocols).test(src);
 }
 
-function processSrc(src) {
+function processSrc(src, options) {
 	if (hasAcceptableProtocol(src)) {
         // The protocol is great and okay!
 		return src;
 	}
-        // We need to convert it
-	return fileUrl(src);
+
+	// We need to convert it
+	const resolvedSrc = path.resolve(options.assetDir, src);
+	return fileUrl(resolvedSrc);
 }
 
 function qualifyImgSources(html, options) {


### PR DESCRIPTION
We weren't resolving the full file paths before converting them into a URL. This has been changed now by adding a line before this process which resolves the image path relative to the markdown file.

This fixes #14.