### PR TITLE
Default assetDir option in the conversion function

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -66,7 +66,6 @@ const options = {
 	defaultStyle: true,
 	source: path.resolve(source),
 	destination: path.resolve(destination),
-	assetDir: path.dirname(path.resolve(source)),
 	styles: style ? path.resolve(style) : null,
 	header: header ? path.resolve(header) : null,
 	footer: footer ? path.resolve(footer) : null,

--- a/index.js
+++ b/index.js
@@ -109,6 +109,8 @@ function convert(options) {
 		throw new Error('Destination path must be provided');
 	}
 
+	options.assetDir = path.dirname(path.resolve(options.source));
+
 	let template = {};
 	const local = {
 		highlightJs,


### PR DESCRIPTION
There was an `assetDir` option being used in the cli script which was undocumented and causing some API users to trip up. In reality this isn't something that needs to be set by an API user so it's been pulled into the main `convert` function and defaults to the directory of the markdown file.

This resolves #19.