### PR TITLE
Make page margin configurable in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,19 @@ Install locally to access the API.
 
 ## Options
 
-* `--style`    A single css stylesheet you wish to apply to the PDF
-* `--header`   A HTML (.html) file to inject into the header of the PDF
-* `--hHeight`  The height of the header section in mm
-* `--footer`   A HTML (.html) file to inject into the footer of the PDF
-* `--fHeight`  The height of the footer section in mm
-* `--noEmoji`  Disables emoji conversions
-* `--debug`    Save the generated html for debugging
-* `--help`     Display this menu
-* `--version`  Displays the application version
+* `--style`         A single css stylesheet you wish to apply to the PDF
+* `--header`        A HTML (.html) file to inject into the header of the PDF
+* `--hHeight`       The height of the header section in mm
+* `--footer`        A HTML (.html) file to inject into the footer of the PDF
+* `--fHeight`       The height of the footer section in mm
+* `--marginTop`     Top margin in mm (default: 10)
+* `--marginLeft`    Left margin in mm (default: 10)
+* `--marginBottom`  Bottom margin in mm (default: 10)
+* `--marginRight`   Right margin in mm (default: 10)
+* `--noEmoji`       Disables emoji conversions
+* `--debug`         Save the generated html for debugging
+* `--help`          Display this menu
+* `--version`       Displays the application version
 
 ## Emoji Support
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Install locally to access the API.
 * `--help`                  - Display this menu
 * `--version`               - Display the application version
 
+Length parameters (`<height>` and `<size>`) require a unit. Valid units are `mm`, `cm`, `in` and `px`.
+
 ## Emoji Support
 
 In text emoji's are also supported, but there are a few instances of shorthand which do not work and require the longhand version, i.e. `:+1:` doesn't work but `:thumbsup:` will.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Install locally to access the API.
 
 * `--style`         A single css stylesheet you wish to apply to the PDF
 * `--header`        A HTML (.html) file to inject into the header of the PDF
-* `--hHeight`       The height of the header section in mm
+* `--hHeight`       The height of the header section
 * `--footer`        A HTML (.html) file to inject into the footer of the PDF
-* `--fHeight`       The height of the footer section in mm
-* `--marginTop`     Top margin in mm (default: 10)
-* `--marginLeft`    Left margin in mm (default: 10)
-* `--marginBottom`  Bottom margin in mm (default: 10)
-* `--marginRight`   Right margin in mm (default: 10)
+* `--fHeight`       The height of the footer section
+* `--marginTop`     Top margin (default: 10mm)
+* `--marginLeft`    Left margin (default: 10mm)
+* `--marginBottom`  Bottom margin (default: 10mm)
+* `--marginRight`   Right margin (default: 10mm)
 * `--noEmoji`       Disables emoji conversions
 * `--debug`         Save the generated html for debugging
 * `--help`          Display this menu

--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ Install locally to access the API.
 
 ## Options
 
-* `--style`         A single css stylesheet you wish to apply to the PDF
-* `--header`        A HTML (.html) file to inject into the header of the PDF
-* `--hHeight`       The height of the header section
-* `--footer`        A HTML (.html) file to inject into the footer of the PDF
-* `--fHeight`       The height of the footer section
-* `--marginTop`     Top margin (default: 20mm)
-* `--marginLeft`    Left margin (default: 20mm)
-* `--marginBottom`  Bottom margin (default: 20mm)
-* `--marginRight`   Right margin (default: 20mm)
-* `--noEmoji`       Disables emoji conversions
-* `--debug`         Save the generated html for debugging
-* `--help`          Display this menu
-* `--version`       Displays the application version
+* `--style=<filename>`      - A single css stylesheet you wish to apply to the PDF
+* `--header=<filename>`     - A HTML (.html) file to inject into the header of the PDF
+* `--h-height=<height>`     - The height of the header section
+* `--footer=<filename>`     - A HTML (.html) file to inject into the footer of the PDF
+* `--f-height=<height>`     - The height of the footer section
+* `--border-top=<size>`     - Top border (default: 20mm)
+* `--border-left=<size>`    - Left border (default: 20mm)
+* `--border-bottom=<size>`  - Bottom border (default: 20mm)
+* `--border-right=<size>`   - Right border (default: 20mm)
+* `--no-emoji`              - Disables emoji conversions
+* `--debug`                 - Save the generated html for debugging
+* `--help`                  - Display this menu
+* `--version`               - Display the application version
 
 ## Emoji Support
 
@@ -67,15 +67,15 @@ mdpdf.convert(options).then((pdfPath) => {
 
 ### Options
 
-* source - **required**, a full path to the source markdown file.
-* destination - **required**, a full path to the destination (pdf) file.
-* styles - A full path to a single css stylesheet which is applied last to the PDF.
-* ghStyle - A boolean value of whether or not to use the GitHub Markdown CSS, set to `false` to turn this stylesheet off.
-* defaultStyle - A boolean value of whether or not to use the additional default styles. These styles provide some things like a basic border and font size. Set to `false` to turn stylesheet off.
-* header - A full path to a the Handlebars (`.hbs`) file which will be your header. If you set this, you must set the header height (see below).
-* debug - When this is set the intermediate HTML will be saved into a file, the value of this field should be the full path to the destination HTML.
-* pdf - **required** An object which contains some sub parameters to control the final PDF document
-    * format - **required** Final document format, allowed values are "A3, A4, A5, Legal, Letter, Tabloid"
-    * header - A sub object which contains some header settings
-        * height - Height of the documents header in mm (default 45mm). If you wish to use a header, then this must be set.
-    * border - The document borders
+* `source` (**required**) - Full path to the source markdown file.
+* `destination` (**required**) - Full path to the destination (pdf) file.
+* `styles` - Full path to a single css stylesheet which is applied last to the PDF.
+* `ghStyle` - Boolean value of whether or not to use the GitHub Markdown CSS, set to `false` to turn this stylesheet off.
+* `defaultStyle` - Boolean value of whether or not to use the additional default styles. These styles provide some things like a basic border and font size. Set to `false` to turn stylesheet off.
+* `header` - Full path to a the Handlebars (`.hbs`) file which will be your header. If you set this, you must set the header height (see below).
+* `debug` - When this is set the intermediate HTML will be saved into a file, the value of this field should be the full path to the destination HTML.
+* `pdf` (**required**) - An object which contains some sub parameters to control the final PDF document
+    * `format` (**required**) - Final document format, allowed values are "A3, A4, A5, Legal, Letter, Tabloid"
+    * `header` - A sub object which contains some header settings
+        * `height` - Height of the documents header in mm (default 45mm). If you wish to use a header, then this must be set.
+    * `border` - The document borders

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Install locally to access the API.
 * `--hHeight`       The height of the header section
 * `--footer`        A HTML (.html) file to inject into the footer of the PDF
 * `--fHeight`       The height of the footer section
-* `--marginTop`     Top margin (default: 10mm)
-* `--marginLeft`    Left margin (default: 10mm)
-* `--marginBottom`  Bottom margin (default: 10mm)
-* `--marginRight`   Right margin (default: 10mm)
+* `--marginTop`     Top margin (default: 20mm)
+* `--marginLeft`    Left margin (default: 20mm)
+* `--marginBottom`  Bottom margin (default: 20mm)
+* `--marginRight`   Right margin (default: 20mm)
 * `--noEmoji`       Disables emoji conversions
 * `--debug`         Save the generated html for debugging
 * `--help`          Display this menu

--- a/bin/index.js
+++ b/bin/index.js
@@ -22,10 +22,10 @@ const cli = meow(`
         --hHeight      The height of the header section
         --footer       A HTML (.html) file to inject into the footer of the PDF
         --fHeight      The height of the footer section
-        --marginTop    Top margin (default: 10mm)
-        --marginLeft   Left margin (default: 10mm)
-        --marginBottom Bottom margin (default: 10mm)
-        --marginRight  Right margin (default: 10mm)
+        --marginTop    Top margin (default: 20mm)
+        --marginLeft   Left margin (default: 20mm)
+        --marginBottom Bottom margin (default: 20mm)
+        --marginRight  Right margin (default: 20mm)
         --noEmoji      Disables emoji conversions
         --debug        Save the generated html for debugging
         --help         Display this menu
@@ -91,10 +91,10 @@ const options = {
 			height: footerHeight || null
 		},
 		border: {
-			top: marginTop || '10mm',
-			left: marginLeft || '10mm',
-			bottom: marginBottom || '10mm',
-			right: marginRight || '10mm'
+			top: marginTop || '20mm',
+			left: marginLeft || '20mm',
+			bottom: marginBottom || '20mm',
+			right: marginRight || '20mm'
 		}
 	}
 };

--- a/bin/index.js
+++ b/bin/index.js
@@ -17,15 +17,19 @@ const cli = meow(`
         $ mdpdf README.md --footer footer.hbs --fHeight 22 --debug
 
     Options:
-        --style    A single css stylesheet you wish to apply to the PDF
-        --header   A HTML (.html) file to inject into the header of the PDF
-        --hHeight  The height of the header section in mm
-        --footer   A HTML (.html) file to inject into the footer of the PDF
-        --fHeight  The height of the footer section in mm
-		--noEmoji  Disables emoji conversions
-        --debug    Save the generated html for debugging
-        --help     Display this menu
-        --version  Displays the application version
+        --style        A single css stylesheet you wish to apply to the PDF
+        --header       A HTML (.html) file to inject into the header of the PDF
+        --hHeight      The height of the header section in mm
+        --footer       A HTML (.html) file to inject into the footer of the PDF
+        --fHeight      The height of the footer section in mm
+        --marginTop    Top margin in mm (default: 10)
+        --marginLeft   Left margin in mm (default: 10)
+        --marginBottom Bottom margin in mm (default: 10)
+        --marginRight  Right margin in mm (default: 10)
+        --noEmoji      Disables emoji conversions
+        --debug        Save the generated html for debugging
+        --help         Display this menu
+        --version      Displays the application version
 `, {
 	alias: {
 		s: 'style',
@@ -61,6 +65,10 @@ const header = cli.flags.header;
 const headerHeight = cli.flags.hHeight;
 const footer = cli.flags.footer;
 const footerHeight = cli.flags.fHeight;
+const marginTop = cli.flags.marginTop;
+const marginLeft = cli.flags.marginLeft;
+const marginBottom = cli.flags.marginBottom;
+const marginRight = cli.flags.marginRight;
 
 const options = {
 	ghStyle: !style,
@@ -83,10 +91,10 @@ const options = {
 			height: footerHeight ? footerHeight + 'mm' : null
 		},
 		border: {
-			top: '10mm',
-			left: '10mm',
-			bottom: '10mm',
-			right: '10mm'
+			top: (marginTop ? marginTop : 10) + 'mm',
+			left: (marginLeft ? marginLeft : 10) + 'mm',
+			bottom: (marginBottom ? marginBottom : 10) + 'mm',
+			right: (marginRight ? marginRight : 10) + 'mm'
 		}
 	}
 };

--- a/bin/index.js
+++ b/bin/index.js
@@ -9,27 +9,30 @@ const cli = meow(`
     Usage:
         $ mdpdf <source> [<destination>] [options]
 
-    <source> must be a markdown file, with the extension .md
+    <source> must be a markdown file, with the extension '.md'.
 
     Examples:
         $ mdpdf README.md
-        $ mdpdf README.md --style styles.css --header header.hbs --hHeight 22
-        $ mdpdf README.md --footer footer.hbs --fHeight 22 --debug
+        $ mdpdf README.md --style=styles.css --header=header.hbs --h-height=22mm
+        $ mdpdf README.md --footer=footer.hbs --f-height=22mm --debug
+        $ mdpdf README.md --border-left=30mm
 
     Options:
-        --style        A single css stylesheet you wish to apply to the PDF
-        --header       A HTML (.html) file to inject into the header of the PDF
-        --hHeight      The height of the header section
-        --footer       A HTML (.html) file to inject into the footer of the PDF
-        --fHeight      The height of the footer section
-        --marginTop    Top margin (default: 20mm)
-        --marginLeft   Left margin (default: 20mm)
-        --marginBottom Bottom margin (default: 20mm)
-        --marginRight  Right margin (default: 20mm)
-        --noEmoji      Disables emoji conversions
-        --debug        Save the generated html for debugging
-        --help         Display this menu
-        --version      Displays the application version
+        --style=<filename>      A single css stylesheet you wish to apply to the PDF
+        --header=<filename>     A HTML (.html) file to inject into the header of the PDF
+        --h-height=<height>     The height of the header section
+        --footer=<filename>     A HTML (.html) file to inject into the footer of the PDF
+        --f-height=<height>     The height of the footer section
+        --border-top=<size>     Top border (default: 20mm)
+        --border-left=<size>    Left border (default: 20mm)
+        --border-bottom=<size>  Bottom border (default: 20mm)
+        --border-right=<size>   Right border (default: 20mm)
+        --no-emoji              Disables emoji conversions
+        --debug                 Save the generated html for debugging
+        --help                  Display this menu
+        --version               Display the application version
+
+        Length parameters (<height> and <size>) require a unit. Valid units are mm, cm, in and px.
 `, {
 	alias: {
 		s: 'style',

--- a/bin/index.js
+++ b/bin/index.js
@@ -19,13 +19,13 @@ const cli = meow(`
     Options:
         --style        A single css stylesheet you wish to apply to the PDF
         --header       A HTML (.html) file to inject into the header of the PDF
-        --hHeight      The height of the header section in mm
+        --hHeight      The height of the header section
         --footer       A HTML (.html) file to inject into the footer of the PDF
-        --fHeight      The height of the footer section in mm
-        --marginTop    Top margin in mm (default: 10)
-        --marginLeft   Left margin in mm (default: 10)
-        --marginBottom Bottom margin in mm (default: 10)
-        --marginRight  Right margin in mm (default: 10)
+        --fHeight      The height of the footer section
+        --marginTop    Top margin (default: 10mm)
+        --marginLeft   Left margin (default: 10mm)
+        --marginBottom Bottom margin (default: 10mm)
+        --marginRight  Right margin (default: 10mm)
         --noEmoji      Disables emoji conversions
         --debug        Save the generated html for debugging
         --help         Display this menu
@@ -85,16 +85,16 @@ const options = {
 		quality: '100',
 		base: path.join('file://', __dirname, '/assets/'),
 		header: {
-			height: headerHeight ? headerHeight + 'mm' : null
+			height: headerHeight || null
 		},
 		footer: {
-			height: footerHeight ? footerHeight + 'mm' : null
+			height: footerHeight || null
 		},
 		border: {
-			top: (marginTop ? marginTop : 10) + 'mm',
-			left: (marginLeft ? marginLeft : 10) + 'mm',
-			bottom: (marginBottom ? marginBottom : 10) + 'mm',
-			right: (marginRight ? marginRight : 10) + 'mm'
+			top: marginTop || '10mm',
+			left: marginLeft || '10mm',
+			bottom: marginBottom || '10mm',
+			right: marginRight || '10mm'
 		}
 	}
 };

--- a/bin/index.js
+++ b/bin/index.js
@@ -65,10 +65,10 @@ const header = cli.flags.header;
 const headerHeight = cli.flags.hHeight;
 const footer = cli.flags.footer;
 const footerHeight = cli.flags.fHeight;
-const marginTop = cli.flags.marginTop;
-const marginLeft = cli.flags.marginLeft;
-const marginBottom = cli.flags.marginBottom;
-const marginRight = cli.flags.marginRight;
+const borderTop = cli.flags.borderTop;
+const borderLeft = cli.flags.borderLeft;
+const borderBottom = cli.flags.borderBottom;
+const borderRight = cli.flags.borderRight;
 
 const options = {
 	ghStyle: !style,
@@ -91,10 +91,10 @@ const options = {
 			height: footerHeight || null
 		},
 		border: {
-			top: marginTop || '20mm',
-			left: marginLeft || '20mm',
-			bottom: marginBottom || '20mm',
-			right: marginRight || '20mm'
+			top: borderTop || '20mm',
+			left: borderLeft || '20mm',
+			bottom: borderBottom || '20mm',
+			right: borderRight || '20mm'
 		}
 	}
 };


### PR DESCRIPTION
Hi,

I added some changes to the CLI of your nice application.

1. Added CLI parameters for top, left, bottom and right margin/border of pages to make the user override the default settings in the command line.
2. Changed the length values to require units (`--hHeight=20mm` instead of `--hHeight=20`). This is more consistent with the API where you have to pass units aswell. Also it makes it possible to use different units, e.g. `mm`, `cm` or `in`.
3. The default page margin is now `20mm` instead of `10mm`.

In my opinion, this makes CLI usage more comfortable. :) Let me know if you don't agree with any of these changes.