### PR TITLE
Added support for orientation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,22 @@ Install locally to access the API.
 
 ## Options
 
-* `--style=<filename>`      - A single css stylesheet you wish to apply to the PDF
-* `--header=<filename>`     - A HTML (.html) file to inject into the header of the PDF
-* `--h-height=<height>`     - The height of the header section
-* `--footer=<filename>`     - A HTML (.html) file to inject into the footer of the PDF
-* `--f-height=<height>`     - The height of the footer section
-* `--border=<size>`         - Border (top, left, bottom, right; default: 20mm)
-* `--border-top=<size>`     - Top border (default: 20mm)
-* `--border-left=<size>`    - Left border (default: 20mm)
-* `--border-bottom=<size>`  - Bottom border (default: 20mm)
-* `--border-right=<size>`   - Right border (default: 20mm)
-* `--no-emoji`              - Disables emoji conversions
-* `--debug`                 - Save the generated html for debugging
-* `--help`                  - Display this menu
-* `--version`               - Display the application version
+* `--style=<filename>`          - A single css stylesheet you wish to apply to the PDF
+* `--header=<filename>`         - A HTML (.html) file to inject into the header of the PDF
+* `--h-height=<height>`         - The height of the header section
+* `--footer=<filename>`         - A HTML (.html) file to inject into the footer of the PDF
+* `--f-height=<height>`         - The height of the footer section
+* `--border=<size>`             - Border (top, left, bottom, right; default: 20mm)
+* `--border-top=<size>`         - Top border (default: 20mm)
+* `--border-left=<size>`        - Left border (default: 20mm)
+* `--border-bottom=<size>`      - Bottom border (default: 20mm)
+* `--border-right=<size>`       - Right border (default: 20mm)
+* `--no-emoji`                  - Disables emoji conversions
+* `--debug`                     - Save the generated html for debugging
+* `--help`                      - Display this menu
+* `--version`                   - Display the application version
+* `--format=<format>`           - PDF size format: A3, A4, A5, Legal, Letter, Tabloid (Default: A4)
+* `--orientation=<orientation>` - PDF orientation: portrait or landscape (Default: portrait)
 
 Length parameters (`<height>` and `<size>`) require a unit. Valid units are `mm`, `cm`, `in` and `px`.
 
@@ -65,7 +67,8 @@ let options = {
     destination: path.join(__dirname, 'output.pdf'),
     styles: path.join(__dirname, 'md-styles.css'),
     pdf: {
-        format: 'A4'
+        format: 'A4',
+        orientation: 'portrait'
     }
 };
 
@@ -87,7 +90,7 @@ mdpdf.convert(options).then((pdfPath) => {
 * `debug` - When this is set the intermediate HTML will be saved into a file, the value of this field should be the full path to the destination HTML.
 * `pdf` (**required**) - An object which contains some sub parameters to control the final PDF document
     * `format` (**required**) - Final document format, allowed values are "A3, A4, A5, Legal, Letter, Tabloid"
+    * `orientation` - Final document size orientation, allowed values are "potrait, orientation"
     * `header` - A sub object which contains some header settings
         * `height` - Height of the documents header in mm (default 45mm). If you wish to use a header, then this must be set.
     * `border` - The document borders
-    

--- a/bin/index.js
+++ b/bin/index.js
@@ -48,7 +48,7 @@ const cli = meow(`
 		f: 'footer',
 		d: 'debug',
 		v: 'version',
-    o: 'orientation'
+		o: 'orientation'
 	}
 });
 
@@ -109,7 +109,7 @@ const options = {
 	debug: debug ? source.slice(0, source.indexOf('.md')) + '.html' : null,
 	pdf: {
 		format: format,
-    orientation: orientation,
+		orientation: orientation,
 		quality: '100',
 		base: path.join('file://', __dirname, '/assets/'),
 		header: {

--- a/bin/index.js
+++ b/bin/index.js
@@ -48,6 +48,7 @@ const cli = meow(`
 		f: 'footer',
 		d: 'debug',
 		v: 'version',
+		r: 'format',
 		o: 'orientation'
 	}
 });
@@ -82,8 +83,8 @@ const borderTop = cli.flags.borderTop || border;
 const borderLeft = cli.flags.borderLeft || border;
 const borderBottom = cli.flags.borderBottom || border;
 const borderRight = cli.flags.borderRight || border;
-const format = cli.flags.format || 'A4';
-const orientation = cli.flags.orientation || 'portrait';
+const pdfFormat = cli.flags.format || 'A4';
+const pdfOrientation = cli.flags.orientation || 'portrait';
 
 // Name of the environement variable
 const envStyleName = 'MDPDF_STYLES';
@@ -108,8 +109,8 @@ const options = {
 	noEmoji: cli.flags.noEmoji || false,
 	debug: debug ? source.slice(0, source.indexOf('.md')) + '.html' : null,
 	pdf: {
-		format: format,
-		orientation: orientation,
+		format: pdfFormat,
+		orientation: pdfOrientation,
 		quality: '100',
 		base: path.join('file://', __dirname, '/assets/'),
 		header: {

--- a/bin/index.js
+++ b/bin/index.js
@@ -19,23 +19,25 @@ const cli = meow(`
         $ mdpdf README.md --border-left=30mm
 
     Options:
-        --style=<filename>      A single css stylesheet you wish to apply to the PDF
-        --header=<filename>     A HTML (.html) file to inject into the header of the PDF
-        --h-height=<height>     The height of the header section
-        --footer=<filename>     A HTML (.html) file to inject into the footer of the PDF
-        --f-height=<height>     The height of the footer section
-        --border=<size>         Border (top, left, bottom, right; default: 20mm)
-        --border-top=<size>     Top border (default: 20mm)
-        --border-left=<size>    Left border (default: 20mm)
-        --border-bottom=<size>  Bottom border (default: 20mm)
-        --border-right=<size>   Right border (default: 20mm)
-        --no-emoji              Disables emoji conversions
-        --debug                 Save the generated html for debugging
-        --help                  Display this menu
-        --version               Display the application version
+        --style=<filename>           A single css stylesheet you wish to apply to the PDF
+        --header=<filename>          A HTML (.html) file to inject into the header of the PDF
+        --h-height=<height>          The height of the header section
+        --footer=<filename>          A HTML (.html) file to inject into the footer of the PDF
+        --f-height=<height>          The height of the footer section
+        --border=<size>              Border (top, left, bottom, right; default: 20mm)
+        --border-top=<size>          Top border (default: 20mm)
+        --border-left=<size>         Left border (default: 20mm)
+        --border-bottom=<size>       Bottom border (default: 20mm)
+        --border-right=<size>        Right border (default: 20mm)
+        --no-emoji                   Disables emoji conversions
+        --debug                      Save the generated html for debugging
+        --help                       Display this menu
+        --version                    Display the application version
+        --format=<format>            PDF size format: A3, A4, A5, Legal, Letter, Tabloid (Default: A4)
+        --orientation=<orientation>  PDF orientation: portrait or landscape (Default: portrait)
 
 		Length parameters (<height> and <size>) require a unit. Valid units are mm, cm, in and px.
-		
+
 	Global Settings:
 		You can also set a global default stylesheet by setting the MDPDF_STYLES environment
 		variable as the path to your single css stylesheet. The --style flag will override this.
@@ -45,7 +47,8 @@ const cli = meow(`
 		h: 'header',
 		f: 'footer',
 		d: 'debug',
-		v: 'version'
+		v: 'version',
+    o: 'orientation'
 	}
 });
 
@@ -79,6 +82,8 @@ const borderTop = cli.flags.borderTop || border;
 const borderLeft = cli.flags.borderLeft || border;
 const borderBottom = cli.flags.borderBottom || border;
 const borderRight = cli.flags.borderRight || border;
+const format = cli.flags.format || 'A4';
+const orientation = cli.flags.orientation || 'portrait';
 
 // Name of the environement variable
 const envStyleName = 'MDPDF_STYLES';
@@ -103,7 +108,8 @@ const options = {
 	noEmoji: cli.flags.noEmoji || false,
 	debug: debug ? source.slice(0, source.indexOf('.md')) + '.html' : null,
 	pdf: {
-		format: 'A4',
+		format: format,
+    orientation: orientation,
 		quality: '100',
 		base: path.join('file://', __dirname, '/assets/'),
 		header: {

--- a/examples/api/index.js
+++ b/examples/api/index.js
@@ -11,7 +11,7 @@ const options = {
 	header: path.join(__dirname, 'header.hbs'),
 	pdf: {
 		format: 'A4',
-    orientation: 'portrait',
+		orientation: 'portrait',
 		quality: '100',
 		header: {
 			height: '20mm'

--- a/examples/api/index.js
+++ b/examples/api/index.js
@@ -11,6 +11,7 @@ const options = {
 	header: path.join(__dirname, 'header.hbs'),
 	pdf: {
 		format: 'A4',
+    orientation: 'portrait',
 		quality: '100',
 		header: {
 			height: '20mm'

--- a/examples/api/md-file.md
+++ b/examples/api/md-file.md
@@ -44,7 +44,8 @@ let options = {
     destination: path.join(__dirname, 'output.pdf'),
     styles: path.join(__dirname, 'md-styles.css'),
     pdf: {
-        format: 'A4'
+        format: 'A4',
+        orientation: 'portrait',
     }
 };
 
@@ -66,6 +67,7 @@ mdpdf.convert(options).then((pdfPath) => {
 * debug - When this is set the intermediate HTML will be saved into a file, the value of this field should be the full path to the destination HTML.
 * pdf - **required** An object which contains some sub parameters to control the final PDF document
     * format - **required** Final document format, allowed values are "A3, A4, A5, Legal, Letter, Tabloid"
+    * orientation - Final document size orientation, allowed values are "potrait, orientation"
     * header - A sub object which contains some header settings
         * height - Height of the documents header in mm (default 45mm). If you wish to use a header, then this must be set.
     * border - The document borders

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -17,7 +17,7 @@ const createOptions = function (options) {
 		debug: debug ? source.slice(0, source.indexOf('.md')) + '.html' : null,
 		pdf: {
 			format: 'A4',
-      orientation: 'portrait',
+			orientation: 'portrait',
 			base: path.join('file://', __dirname, '/assets/'),
 			header: {
 				height: null

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -17,6 +17,7 @@ const createOptions = function (options) {
 		debug: debug ? source.slice(0, source.indexOf('.md')) + '.html' : null,
 		pdf: {
 			format: 'A4',
+      orientation: 'portrait',
 			base: path.join('file://', __dirname, '/assets/'),
 			header: {
 				height: null


### PR DESCRIPTION
I use this indirectly via the atom plugin markdown-pdf and recently needed to export a PDF in landscape orientation.

It's a simple change but I don't know if this is meant to be part of the scope.

Thanks for considering this!