### PR TITLE
Added import of path in the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The API is very straight forward with a single function `convert()` which takes 
 
 ```JavaScript
 const mdpdf = require('mdpdf');
+const path = require('path');
 
 let options = {
     source: path.join(__dirname, 'README.md'),


### PR DESCRIPTION
To make sure that the example code works after a simple copy paste, module path needs to be imported.