### PR TITLE
Disable sandboxing for puppeteer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ function createPdf(html, options) {
 
   return writeFile(tempHtmlPath, html)
     .then(() => {
-      return puppeteer.launch({ headless: true });
+      return puppeteer.launch({ headless: true , args: ['--no-sandbox', '--disable-setuid-sandbox'] });
     })
     .then(newBrowser => {
       browser = newBrowser;


### PR DESCRIPTION
I'm upgrading the markdown-pdf atom package to the latest mdpdf version.

I'm facing a problem with puppeteer: I cannot run a sand-boxed version of chromium on Debian 10 because the system don't let puppeteer clone a namespace from a non privileged user.

Some fixes are documented here https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#alternative-setup-setuid-sandbox

But I'm against allowing unprivileged users to run namespaces because of the many answers I found here : https://security.stackexchange.com/a/209533

Puppeteer allow to disable sandboxing, but says : `If you absolutely trust the content you open in Chrome, you can launch Chrome with the --no-sandbox argument`

So I though it would have less impact if we disable sandbox in this packages instead of enabling user namespace cloning system wide. Also I don't consider markdown html page as content that you can't be trusted.