### PR TITLE
Add `--gh-style` flag to command-line interface  

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Install locally to access the API.
 * `--border-left=<size>`        - Left border (default: 20mm)
 * `--border-bottom=<size>`      - Bottom border (default: 20mm)
 * `--border-right=<size>`       - Right border (default: 20mm)
+* `--gh-style`                  - Enable default gh-styles, when --style is used
 * `--no-emoji`                  - Disables emoji conversions
 * `--debug`                     - Save the generated html for debugging
 * `--help`                      - Display this menu

--- a/bin/index.js
+++ b/bin/index.js
@@ -30,6 +30,7 @@ const cli = meow(
         --border-left=<size>         Left border (default: 20mm)
         --border-bottom=<size>       Bottom border (default: 20mm)
         --border-right=<size>        Right border (default: 20mm)
+        --gh-style                   Enable default gh-styles, when --style is used
         --no-emoji                   Disables emoji conversions
         --debug                      Save the generated html for debugging
         --help                       Display this menu
@@ -89,6 +90,7 @@ const borderBottom = cli.flags.borderBottom || border;
 const borderRight = cli.flags.borderRight || border;
 const pdfFormat = cli.flags.format || 'A4';
 const pdfOrientation = cli.flags.orientation || 'portrait';
+const ghStyleFlag = cli.flags.ghStyle || false;
 
 // Name of the environement variable
 const envStyleName = 'MDPDF_STYLES';
@@ -103,7 +105,7 @@ if (!style && process.env[envStyleName]) {
 }
 
 const options = {
-  ghStyle: !style,
+  ghStyle: style ? ghStyleFlag : true,
   defaultStyle: true,
   source: path.resolve(source),
   destination: path.resolve(destination),

--- a/tests/index.js
+++ b/tests/index.js
@@ -91,6 +91,34 @@ describe('Convert CLI', function() {
         .catch(done);
     });
   });
+
+  context('When custom style is passed', () => {
+    it('HTML file contains the custom style', done => {
+      execa('./bin/index.js', ['./tests/test.md', '--style=./tests/test.css', '--debug'])
+        .then(() => {
+          const htmlContent = fs.readFileSync('./tests/test.html');
+          const cssContent = fs.readFileSync('./tests/test.css');
+          const ghStyleContent = fs.readFileSync('./src/assets/github-markdown-css.css');
+
+          htmlContent.includes(cssContent).should.be.true();
+          htmlContent.includes(ghStyleContent).should.be.false();
+          done();
+        });
+    });
+
+    it('HTML file contains the default styles when --gh-style is passed', done => {
+      execa('./bin/index.js', ['./tests/test.md', '--style=./tests/test.css', '--debug', '--gh-style'])
+        .then(() => {
+          const htmlContent = fs.readFileSync('./tests/test.html');
+          const cssContent = fs.readFileSync('./tests/test.css');
+          const ghStyleContent = fs.readFileSync('./src/assets/github-markdown-css.css');
+
+          htmlContent.includes(cssContent).should.be.true();
+          htmlContent.includes(ghStyleContent).should.be.true();
+          done();
+        });
+    });
+  });
 });
 
 describe('Convert API', function() {

--- a/tests/test.css
+++ b/tests/test.css
@@ -1,0 +1,5 @@
+/* CSS to test --style and --gh-style flag */
+
+.underlinedTestingStuff {
+    text-decoration: underline;
+}


### PR DESCRIPTION
#### Problem:
When using a custom `.css` style, the default gh-style becomes disabled. 

#### Solution:
- Add a new flag `--gh-style` that can be used alongside `--style` to enable the default gh-style.
- Add needed unit tests.
- Update documentation.

#### Proof:
![gh_styles_proof](https://user-images.githubusercontent.com/26286907/71643973-edf0f500-2cd1-11ea-89ca-ea3a8be80651.gif)


#### Related issues:
https://github.com/BlueHatbRit/mdpdf/issues/34

<hr />

Thanks so much, for the awesome converter!