### PR TITLE
Npm: Update handlebars to a non-vulnerable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bluebird": "^3.4.7",
     "cheerio": "^0.22.0",
     "file-url": "^2.0.2",
-    "handlebars": "^4.7.6",
+    "handlebars": ">=4.7.7",
     "loophole": "^1.1.0",
     "meow": "^5.0.0",
     "prettier": "^1.15.3",


### PR DESCRIPTION
CVE-2021-23369. The earliest fixed version is 4.7.7.

Related to https://github.com/BlueHatbRit/mdpdf/pull/101, where only package-lock.json was updated.