### PR TITLE
Fixes #46: remove simple line breaks for GH style

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,11 +48,12 @@ function getAllStyles(options) {
   };
 }
 
-function parseMarkdownToHtml(markdown, convertEmojis, enableHighlight) {
+function parseMarkdownToHtml(markdown, convertEmojis, enableHighlight, simpleLineBreaks) {
   showdown.setFlavor('github');
   const options = {
     prefixHeaderId: false,
     ghCompatibleHeaderId: true,
+    simpleLineBreaks,
     extensions: []
   };
   
@@ -99,7 +100,7 @@ async function convert(options) {
     prepareFooter(options).then(v => options.footer = v),
   ];
 
-  let content = parseMarkdownToHtml(await source, !options.noEmoji, !options.noHighlight);
+  let content = parseMarkdownToHtml(await source, !options.noEmoji, !options.noHighlight, !options.ghStyle);
 
   // This step awaits so options is valid
   await Promise.all(promises);


### PR DESCRIPTION
Fixes #46 
Before a line break in the md file would generate a line break in the pdf file but to match the way GH renders Markdown it should be rendered in the same line in the pdf file. This PR fixes this.

Here is a before and after of this text:

```
Hi,
how 
are 
you?
```

Before:
![Screenshot from 2022-08-16 15-44-52](https://user-images.githubusercontent.com/92874541/184956702-9e2c2ab5-5b1b-4d9e-9827-69bbd5ace6e2.png)

After:
![Screenshot from 2022-08-16 15-45-33](https://user-images.githubusercontent.com/92874541/184956719-81b20ecd-5c75-4cf7-946a-35db9bd46d36.png)

